### PR TITLE
feat: Complete WebSocket → SSE migration for bookshelf scanning (Phase 3)

### DIFF
--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/BookshelfScanning/BookshelfScannerView.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/BookshelfScanning/BookshelfScannerView.swift
@@ -522,13 +522,13 @@ class BookshelfScanModel {
         self.lastSavedImagePath = await saveOriginalImage(image)
 
         do {
-            // Use new WebSocket method for real-time progress updates
-            let (capturedImage, detectedBooks, suggestions) = try await BookshelfAIService.shared.processBookshelfImageWithWebSocket(image) { progress, stage in
+            // Use SSE method for real-time progress updates
+            let (capturedImage, detectedBooks, suggestions) = try await BookshelfAIService.shared.processBookshelfImageWithProgress(image) { progress, stage in
                 // Progress handler runs on MainActor - safe for UI updates
                 self.currentProgress = progress
                 self.currentStage = stage
                 #if DEBUG
-                print("📸 WebSocket progress: \(Int(progress * 100))% - \(stage)")
+                print("📸 SSE progress: \(Int(progress * 100))% - \(stage)")
                 #endif
             }
 


### PR DESCRIPTION
## Summary

Implements **Phase 3** of the V2 API migration per `docs/V2_MIGRATION_GUIDE.md` and `docs/migration-plans/websocket-to-sse-migration.md`. This PR completes the migration from WebSocket to Server-Sent Events (SSE) for real-time progress tracking in the bookshelf scanning workflow.

### Changes

#### ✅ Migrated to SSE

**BookshelfScannerView.swift:**
- ✅ Updated to use `processBookshelfImageWithProgress` (SSE-based)
- ❌ Removed deprecated `processBookshelfImageWithWebSocket` usage
- Updated progress logging from "WebSocket progress" → "SSE progress"

### Infrastructure Status

All SSE infrastructure was already in place from previous work:

#### ✅ Already Implemented
- **SSEClient** - Comprehensive actor-based SSE client with:
  - Automatic reconnection with exponential backoff
  - Proper SSE event parsing (handles \r, \n, \r\n)
  - AsyncStream integration for Swift concurrency
  - Support for multiple event types (progress, completed, failed, etc.)
  
- **processBookshelfImageWithProgress** - SSE-first implementation
  - Falls back to polling if SSE unavailable
  - @MainActor progress callbacks for UI updates
  
- **Deprecation Warnings** - All WebSocket APIs marked deprecated:
  - `processBookshelfImageWithWebSocket` - deprecated since earlier
  - `websocketUrl` field in DTOs - deprecated since v3.2

### Breaking Changes

**None** - This is a seamless migration:
- WebSocket methods remain available (deprecated) for backward compatibility
- SSE infrastructure handles all progress tracking
- No API contract changes required

### Testing

- ✅ **Build**: Succeeds with zero errors
- ✅ **Migration**: All active WebSocket usage migrated to SSE
- ⚠️ **Existing Warnings**: Deprecated `token` field (backward compatibility, pre-existing technical debt)

### Migration Progress

| Phase | Status | Completion |
|-------|--------|------------|
| **Phase 1: Search API** | ✅ **Complete** | Merged in PR #138 |
| **Phase 2: Enrichment API** | ✅ **Complete** | Merged in PR #139 |
| **Phase 3: WebSocket → SSE** | ✅ **Complete** | This PR |
| **Phase 4: Import Validation** | ⏳ **Pending** | Next phase |

### WebSocket Sunset Timeline

Per `docs/migration-plans/websocket-to-sse-migration.md`:

- **NOW**: All active usage migrated to SSE ✅
- **Q3 2026**: Backend WebSocket removal deadline
- **Before Q3 2026**: Remove all deprecated WebSocket infrastructure

### Files Changed

- `BooksTrackerPackage/Sources/BooksTrackerFeature/BookshelfScanning/BookshelfScannerView.swift` - Migrated to SSE method

**Minimal change** - Only 3 lines modified (method name + logging)

### Next Steps

1. **Merge this PR** - Complete Phase 3
2. **Phase 4**: Verify import workflow V2 compliance
3. **Q3 2026**: Remove deprecated WebSocket infrastructure

### Implementation Notes

The migration was straightforward because:
1. SSE infrastructure was already comprehensive
2. The deprecated method already delegated to SSE internally
3. Only caller usage needed updating (this PR)

This demonstrates the value of the phased migration approach with backward compatibility.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>